### PR TITLE
Fix activation dependency on helper functions

### DIFF
--- a/docs/complete-overview.txt
+++ b/docs/complete-overview.txt
@@ -1,0 +1,75 @@
+KRYDDBOX FÖRENINGSPORTAL – SAMMANFATTNING (SPEC + TILLÄGG)
+
+1) SYFTE OCH HUVUDIDÉ
+- Bygga en komplett WordPress-plugin med React-frontend där föreningar säljer föreningsboxar, ser statistik/material och följer provisioner. Kryddbox/Superadmin ska kunna administrera föreningar, admins och kampanjer. Systemet ska vara mobilt, modernt, automatiserat och driftsäkert.
+
+2) ROLLER
+- Superadmin: Full kontroll; sätter global och admin-provision; hanterar mallar, funktioner, kampanjer; kan “visa som användare”; kan aktivera/inaktivera alla moduler.
+- Admin: Ansvarar för tilldelade föreningar; får provision baserat på föreningsförsäljning; kan administrera sina föreningar; kan “visa som föreningsansvarig/moderator”.
+- Föreningsansvarig: Hanterar föreningens kampanj, medlemmar och material; ser försäljnings- och provisionsstatistik.
+- Föreningsmoderator: Kan se statistik, ladda ner material och lägga in offlineordrar.
+
+3) AUTOMATISERING (FÖRLÖPNING)
+- Vid skapande av förening: generera unik länk + kod, QR, affischer/flyers/SoMe-texter/mailmallar och standardkampanj.
+- Under kampanj: automatiska mail (start/mitten/slut), automatisk orderkoppling via länk/kod/QR, realtidsstatistik.
+- Efter kampanj: automatiserad rapport till förening och underlag för provision till förening + admin.
+
+4) PROVISIONSSYSTEM
+- Förening: provision per box (globalt eller per förening).
+- Admin: modell väljs av Superadmin (fast belopp per box, procent av föreningens provision eller trappmodell). Admin-dashboard visar total försäljning, provision och föreningsresultat.
+
+5) FRONTEND (REACT)
+- Design: modernt, stilrent, mobilanpassat; kort/grafer/QR/material lättillgängligt.
+- Admin-portal: dashboard, föreningar, admins, kampanjer, rapporter, inställningar.
+- Föreningsportal: dashboard, medlemmar, material, kampanjinfo.
+- Återanvändbara komponenter: StatsCard, ChartBlock/SalesChart, QRCard, MaterialCard, DataTable/Table, DiagnosticsPanel, layout (AdminLayout/OrgLayout/NavBar) och UI-element (Button/Card/Modal m.m.).
+
+6) SUPPORTFUNKTIONER
+- “Visa som användare” (Superadmin kan se alla, Admin sina föreningar).
+- Loggar över alla ändringar (kb_logs) och diagnostik-panel.
+- Lista med osynkade ordrar; notiser för viktiga händelser.
+- Snabbåtgärder: regenerera QR, skicka om mail, låsa upp konton, koppla ordrar.
+
+7) DATABASEMODELL (KORT)
+- Egna tabeller: kb_orgs, kb_admins, kb_campaigns, kb_org_provision, kb_order_link, kb_members, kb_sales_aggregates, kb_admin_commissions, kb_material_templates, kb_generated_material, kb_qr_codes, kb_logs, kb_notifications.
+
+8) API (REST, t.ex. /wp-json/kb-forening/v1/)
+- Endpoints för organisationer, kampanjer, statistik (summary/timeseries), medlemmar, material & QR, provision (förening + admin), support (loggar/diagnostik/osynkade ordrar).
+
+9) FEATURE TOGGLES
+- Lagrade i inställning eller tabell; styrs av Superadmin: features.members.enabled, features.qr.auto_generate, features.materials.auto_generate_on_org_create, features.email.automated_campaign_mails, features.admin_commission.enabled, features.stats.advanced_graphs.
+
+10) UTVECKLINGSPLAN (HÖGNIVÅ)
+- Skapa pluginstruktur → skapa tabeller vid aktivering → bygg REST API → bygg React-frontend → WooCommerce-orderintegration → provisionslogik → support/loggar/”visa som” → optimering/caching/UI-finslipning.
+
+11) KODNINGSREGLER
+- Ändra bara det nödvändiga; minimal och isolerad påverkan; bakåtkompatibilitet; ny funktionalitet bakom feature toggles; säkra SQL (preparerade statements); logga strukturella ändringar i kb_logs; använd Git med tydliga commit-meddelanden; ingen refaktorering om inte absolut nödvändigt.
+
+12) FILSTRUKTUR (WP-PLUGIN + REACT)
+- /kb-foreningsportal/kb-foreningsportal.php (loader/hooks); includes/* (klasser för orgs/admins/kampanjer/provision/orders/members/material/qr/logs/notifications/helpers/hooks); admin/views (dashboards, settings, orglist/detail); public (shortcodes, enqueue, css/js); assets/js+css (bundlad React för admin/org); react-app/src (components/pages/api/hooks/context/styles). Shortcode/block renderar div #kb-portal-root med data-mode org/admin.
+
+13) MODULÄR PLUGIN-ARKITEKTUR (TILLÄGG)
+- Huvudplugin: bootstrap + registrerar moduler + renderar setup-sida.
+- Moduler (egna klasser/mappar) med livscykel-API: id/label/description/depends_on + register/boot/deactivate; status kan användas för health-checks.
+- KB_Module_Manager: registrerar moduler, kör boot bara om flagga aktiv och validerar beroenden.
+- KB_Feature_Flags: lagring/cachning i tabell (t.ex. kb_feature_flags med enabled/updated_at/updated_by) och fallback till befintliga flaggor för bakåtkompatibilitet.
+- Setup-sida för superadmin: meny “Kryddbox » Setup & funktioner”; kort per modul med switch, beskrivning, beroenden, status, snabblänkar (regenerera QR, skicka testmail m.m.), logg av ändringar (kb_logs). Toggle via REST-endpoint med nonce + capability manage_options; bekräftelsemodal för moduler med databaspåverkan; health-check visar varningar/fel.
+- Avstängning rensar cron/queue/transients via deactivate(); alla toggle-ändringar loggas med vem/vad/före-efter/IP.
+- Migrering: init-script mappar befintliga feature toggles till tabellen och behåller läsning av gamla optioner tills avvecklat.
+- Föreslagen implementationsordning: 1) Lägg till manager/feature flag-tabell, 2) bryt ut delsystem till moduler, 3) bygg setup-sida, 4) lägg till status/health-check, 5) testa aktivera/deaktivera.
+
+14) EXTRA FÖRBÄTTRINGAR (TILLÄGG)
+- Fältversionering/revisionshistorik för kritiska uppgifter (provision, kampanjdatum, status) med tabell kb_field_revisions; viewer + återställning bakom toggle.
+- API-policys per roll (access-matris och middleware som verifierar roll/ägarskap; tester för policys).
+- Rate limiting/spam-skydd för offentliga endpoints (per IP/länk, larm vid hög frekvens).
+- Signerade/tidsbegränsade material-länkar via proxy-endpoint och tokens.
+- Bakgrundsjobb/queues för tunga mail/material/rapporter (WP Cron/Action Scheduler/extern queue) bakom toggle + statusvy.
+- Självservice-reparationer i diagnostik (återkoppla order, regenerera QR, återpublicera material) med loggning.
+- GDPR/PII-skydd: maskning i loggar/diagnostik, export- och raderingsflöde per medlem, retention/auto-purge.
+- Observability/larm: health-endpoint, metrik (latens/fel/queue), notiser vid fel/anomali kopplat till kb_notifications.
+- Bulkuppladdning: CSV-import för medlemmar och batch offlineordrar med validering/återkoppling och historik.
+- Read-only granskarroll (revision): läsbehörighet till rapporter/provision, blockera skrivningar och visa read-only badge.
+- Backup/restore-rutiner för egna tabeller, snapshot före schemaändring och testad återställning.
+
+15) HELHETSBILD
+- Slutmålet är ett modulärt, säkert och driftsäkert plugin där Superadmin kan slå på/av funktioner, övervaka hälsa och logga ändringar, medan användarna får en smidig portal med automatisering, statistik och materialstöd. Alla förbättringar ovan kan införas stegvis bakom toggles för att bevara stabilitet.

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -1,0 +1,85 @@
+# Kryddbox föreningsportal – modulär plugin-arkitektur
+
+Den här designen beskriver hur vi kan bygga WordPress-pluginet så att varje större funktion aktiveras/avaktiveras separat, med en central setup-sida för superadmin.
+
+## Översikt
+- **Huvudplugin**: ansvarar för bootstrap, registrerar moduler och renderar setup-sidan.
+- **Moduler**: kapslade i egna klasser/mappar, med samma livscykel-API (`register`, `boot`, `deactivate`).
+- **Feature toggles**: lagras i `options` eller egen tabell (`kb_feature_flags`) och caches med `wp_cache`/transients.
+- **Admin-UI**: en “Setup & funktioner”-sida som listar alla moduler med switchar, beskrivningar, beroenden och larm/diagnostik.
+
+## Filstruktur (kort)
+```
+/wp-content/plugins/kb-foreningsportal/
+├─ kb-foreningsportal.php
+├─ /includes/
+│   ├─ class-kb-module-manager.php   (registrerar/modular loader)
+│   ├─ modules/
+│   │   ├─ class-kb-module-members.php
+│   │   ├─ class-kb-module-materials.php
+│   │   ├─ class-kb-module-qr.php
+│   │   ├─ class-kb-module-admin-commission.php
+│   │   ├─ class-kb-module-stats.php
+│   │   ├─ class-kb-module-campaign-mailer.php
+│   │   └─ class-kb-module-support-tools.php
+│   └─ class-kb-feature-flags.php     (persistens + cache för toggles)
+├─ /admin/
+│   ├─ class-kb-admin-setup-page.php  (setup-sidan med switchar och status)
+│   └─ /views/setup-page.php
+```
+
+## Modul-API (förslag)
+```php
+interface KB_Module {
+    public function id(): string;          // t.ex. "members".
+    public function label(): string;       // visningsnamn.
+    public function description(): string; // kort info till setup-sidan.
+    public function depends_on(): array;   // lista av modul-IDn.
+
+    public function register(): void;      // registrera hooks/REST-routes.
+    public function boot(): void;          // körs när WP laddar (om aktiv).
+    public function deactivate(): void;    // städa cron/transients när av.
+}
+```
+- Moduler registreras via `KB_Module_Manager`, men `boot()` körs bara om togglen är aktiv.
+- Beroenden kontrolleras så att t.ex. `campaign_mailer` kräver `campaigns`-modulen.
+- Varje modul kan exponera sin egen `settings_section` på setup-sidan.
+
+## Feature toggles
+- Lagra per modul i `kb_feature_flags` (modul_id, enabled, updated_at, updated_by).
+- Cache:a i `wp_cache`/transient för färre DB-slag; invalidera på toggle-ändring.
+- Koppla till befintliga flaggor (t.ex. `features.members.enabled`) för bakåtkompatibilitet.
+
+## Setup-sida (superadmin)
+- Eget menyalternativ: **Kryddbox » Setup & funktioner**.
+- Innehåll:
+  - Kort per modul med **switch**, beskrivning, beroenden, status (OK/varning/fel), och snabblänkar (t.ex. “Regenerera QR”, “Skicka tests mail”).
+  - Summering över aktiva moduler och logg för senaste ändringar (skriv till `kb_logs`).
+  - “Visa som”-funktion används inte på setup-sidan (endast superadmin har access).
+- Åtgärder:
+  - Toggle POST-anrop till REST-endpoint `/kb-forening/v1/features/{module}` (nonce-skydd, capability `manage_options`).
+  - Bekräftelsemodal för moduler med databaspåverkan (t.ex. medlemmar/provision).
+
+## Säkerhet och stabilitet
+- Alla queries: preparerade statements/`$wpdb->prepare`.
+- Logga alla toggle-ändringar i `kb_logs` (vem, vad, före/efter, IP).
+- Vid avstängning: kör `deactivate()` för att rensa cronjob/queues/transients så inget hänger kvar.
+- Health-check per modul: modul kan exponera `status()` som används på setup-sidan för att visa om beroenden eller externa tjänster (t.ex. mail/QR-renderer) fungerar.
+
+## Migrering av befintliga feature toggles
+- Kartlägg nuvarande flaggor (`features.members.enabled`, `features.qr.auto_generate`, m.fl.).
+- Skapa en init-migration som lägger in default-rader i `kb_feature_flags` baserat på nuvarande optioner.
+- Behåll läsning av gamla optioner som fallback för bakåtkompatibilitet tills helt avvecklat.
+
+## Exempel på modulaktivering
+1) Superadmin slår på **Adminprovision**.
+2) `KB_Module_Manager` markerar flaggan aktiv och kör `register()` + `boot()` för `admin_commission`.
+3) `class-kb-module-admin-commission.php` registrerar sina REST-routes och filtrerar WooCommerce-hookarna.
+4) UI visar status “Aktiv” och senaste ändring i loggen.
+
+## Nästa steg (implementationsordning)
+1. Lägg till `KB_Module_Manager` och `KB_Feature_Flags` + DB-tabell.
+2. Bryt ut befintliga delsystem till moduler (members, materials, qr, admin_commission, stats, campaign_mailer, support_tools).
+3. Bygg setup-sidan (admin) med React/Vue-mini eller klassisk WP-lista + toggles.
+4. Lägg till health-check/status per modul och loggning av ändringar.
+5. Testa flödet: aktivera/deaktivera moduler, kontrollera att hooks/cron/REST bara laddas när aktiv.

--- a/kb-foreningsportal/admin/class-kb-admin-ui.php
+++ b/kb-foreningsportal/admin/class-kb-admin-ui.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Admin UI and setup page for module toggles.
+ */
+class KB_FP_Admin_UI {
+    protected $modules;
+
+    public function __construct( $modules ) {
+        $this->modules = $modules;
+        add_action( 'admin_menu', array( $this, 'register_menu' ) );
+        add_action( 'admin_init', array( $this, 'register_settings' ) );
+    }
+
+    public function register_menu() {
+        add_menu_page(
+            __( 'KB Föreningsportal', 'kb-foreningsportal' ),
+            __( 'KB Portal', 'kb-foreningsportal' ),
+            'manage_options',
+            'kb-foreningsportal',
+            array( $this, 'render_setup_page' ),
+            'dashicons-admin-generic'
+        );
+    }
+
+    public function register_settings() {
+        register_setting( 'kb_fp_features', 'kb_fp_features', 'kb_fp_sanitize_features' );
+    }
+
+    public function render_setup_page() {
+        $features = kb_fp_get_feature_options( $this->modules );
+        $defaults = kb_fp_get_feature_defaults( $this->modules );
+        include KB_FP_PLUGIN_DIR . 'admin/views/admin-settings.php';
+    }
+}
+

--- a/kb-foreningsportal/admin/class-kb-admin-ui.php
+++ b/kb-foreningsportal/admin/class-kb-admin-ui.php
@@ -9,6 +9,7 @@ class KB_FP_Admin_UI {
         $this->modules = $modules;
         add_action( 'admin_menu', array( $this, 'register_menu' ) );
         add_action( 'admin_init', array( $this, 'register_settings' ) );
+        add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
     }
 
     public function register_menu() {
@@ -24,6 +25,15 @@ class KB_FP_Admin_UI {
 
     public function register_settings() {
         register_setting( 'kb_fp_features', 'kb_fp_features', 'kb_fp_sanitize_features' );
+    }
+
+    public function enqueue_assets( $hook ) {
+        if ( 'toplevel_page_kb-foreningsportal' !== $hook ) {
+            return;
+        }
+
+        wp_enqueue_style( 'kb-fp-portal', KB_FP_PLUGIN_URL . 'assets/css/portal.css', array(), KB_FP_VERSION );
+        wp_enqueue_script( 'kb-fp-portal-admin', KB_FP_PLUGIN_URL . 'assets/js/portal-admin.bundle.js', array(), KB_FP_VERSION, true );
     }
 
     public function render_setup_page() {

--- a/kb-foreningsportal/admin/views/admin-admins.php
+++ b/kb-foreningsportal/admin/views/admin-admins.php
@@ -1,0 +1,4 @@
+<div class="wrap">
+    <h1>Placeholder for <?php echo esc_html( basename(__FILE__) ); ?></h1>
+    <p>Denna vy implementeras i React-frontend.</p>
+</div>

--- a/kb-foreningsportal/admin/views/admin-dashboard.php
+++ b/kb-foreningsportal/admin/views/admin-dashboard.php
@@ -1,0 +1,4 @@
+<div class="wrap">
+    <h1>KB Föreningsportal – Dashboard</h1>
+    <p>Översikt över moduler och status kommer här.</p>
+</div>

--- a/kb-foreningsportal/admin/views/admin-org-detail.php
+++ b/kb-foreningsportal/admin/views/admin-org-detail.php
@@ -1,0 +1,4 @@
+<div class="wrap">
+    <h1>Placeholder for <?php echo esc_html( basename(__FILE__) ); ?></h1>
+    <p>Denna vy implementeras i React-frontend.</p>
+</div>

--- a/kb-foreningsportal/admin/views/admin-org-list.php
+++ b/kb-foreningsportal/admin/views/admin-org-list.php
@@ -1,0 +1,4 @@
+<div class="wrap">
+    <h1>Placeholder for <?php echo esc_html( basename(__FILE__) ); ?></h1>
+    <p>Denna vy implementeras i React-frontend.</p>
+</div>

--- a/kb-foreningsportal/admin/views/admin-reports.php
+++ b/kb-foreningsportal/admin/views/admin-reports.php
@@ -1,0 +1,4 @@
+<div class="wrap">
+    <h1>Placeholder for <?php echo esc_html( basename(__FILE__) ); ?></h1>
+    <p>Denna vy implementeras i React-frontend.</p>
+</div>

--- a/kb-foreningsportal/admin/views/admin-settings-page.php
+++ b/kb-foreningsportal/admin/views/admin-settings-page.php
@@ -1,0 +1,4 @@
+<div class="wrap">
+    <h1>Placeholder for <?php echo esc_html( basename(__FILE__) ); ?></h1>
+    <p>Denna vy implementeras i React-frontend.</p>
+</div>

--- a/kb-foreningsportal/admin/views/admin-settings.php
+++ b/kb-foreningsportal/admin/views/admin-settings.php
@@ -1,0 +1,58 @@
+<div class="wrap">
+    <h1><?php esc_html_e( 'KB Föreningsportal – Setup', 'kb-foreningsportal' ); ?></h1>
+    <p><?php esc_html_e( 'Slå av/på moduler och funktioner. Endast Superadmin (manage_options) kan uppdatera.', 'kb-foreningsportal' ); ?></p>
+
+    <form method="post" action="options.php" class="kb-fp-settings">
+        <?php settings_fields( 'kb_fp_features' ); ?>
+        <?php $module_flags = array_map( function( $module ) { return isset( $module['feature_flag'] ) ? $module['feature_flag'] : ''; }, $this->modules ); ?>
+
+        <h2><?php esc_html_e( 'Moduler', 'kb-foreningsportal' ); ?></h2>
+        <div class="kb-fp-modules" style="display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));">
+            <?php foreach ( $this->modules as $id => $module ) :
+                $flag       = isset( $module['feature_flag'] ) ? $module['feature_flag'] : '';
+                $enabled    = isset( $features[ $flag ] ) ? (bool) $features[ $flag ] : true;
+                $depends_on = isset( $module['depends_on'] ) ? $module['depends_on'] : array();
+            ?>
+                <div class="kb-fp-module-card" style="border:1px solid #ccd0d4;border-radius:6px;padding:12px;background:#fff;">
+                    <div style="display:flex;justify-content:space-between;align-items:center;">
+                        <strong><?php echo esc_html( $module['label'] ); ?></strong>
+                        <?php if ( $flag ) : ?>
+                            <label>
+                                <input type="checkbox" name="kb_fp_features[<?php echo esc_attr( $flag ); ?>]" value="1" <?php checked( $enabled ); ?> />
+                                <?php esc_html_e( 'Aktiv', 'kb-foreningsportal' ); ?>
+                            </label>
+                        <?php endif; ?>
+                    </div>
+                    <p style="margin:8px 0 4px;"><?php echo esc_html( $module['description'] ); ?></p>
+                    <?php if ( ! empty( $depends_on ) ) : ?>
+                        <p style="margin:4px 0 0;font-size:12px;color:#555;">
+                            <?php esc_html_e( 'Beroenden:', 'kb-foreningsportal' ); ?>
+                            <?php echo esc_html( implode( ', ', $depends_on ) ); ?>
+                        </p>
+                    <?php endif; ?>
+                </div>
+            <?php endforeach; ?>
+        </div>
+
+        <h2 style="margin-top:24px;"><?php esc_html_e( 'Övriga toggles', 'kb-foreningsportal' ); ?></h2>
+        <table class="form-table" role="presentation">
+            <tbody>
+                <?php foreach ( $defaults as $flag => $default_value ) :
+                    if ( in_array( $flag, $module_flags, true ) ) {
+                        continue;
+                    }
+                    $enabled = isset( $features[ $flag ] ) ? $features[ $flag ] : $default_value;
+                ?>
+                    <tr>
+                        <th scope="row"><label for="<?php echo esc_attr( $flag ); ?>"><?php echo esc_html( $flag ); ?></label></th>
+                        <td>
+                            <input type="checkbox" id="<?php echo esc_attr( $flag ); ?>" name="kb_fp_features[<?php echo esc_attr( $flag ); ?>]" value="1" <?php checked( $enabled ); ?> />
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+
+        <?php submit_button(); ?>
+    </form>
+</div>

--- a/kb-foreningsportal/assets/css/portal.css
+++ b/kb-foreningsportal/assets/css/portal.css
@@ -1,0 +1,2 @@
+/* Placeholder CSS for KB Föreningsportal. Build React app to overwrite. */
+#kb-portal-root { font-family: Arial, sans-serif; }

--- a/kb-foreningsportal/assets/js/portal-admin.bundle.js
+++ b/kb-foreningsportal/assets/js/portal-admin.bundle.js
@@ -1,0 +1,1 @@
+(()=>{console.info('KB Föreningsportal admin bundle placeholder loaded. Build React app via react-app/ to overwrite.');})();

--- a/kb-foreningsportal/assets/js/portal-org.bundle.js
+++ b/kb-foreningsportal/assets/js/portal-org.bundle.js
@@ -1,0 +1,1 @@
+(()=>{console.info('KB Föreningsportal org bundle placeholder loaded. Build React app via react-app/ to overwrite.');})();

--- a/kb-foreningsportal/includes/class-kb-activator.php
+++ b/kb-foreningsportal/includes/class-kb-activator.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Fired during plugin activation.
+ */
+class KB_FP_Activator {
+
+    public static function activate() {
+        // Ensure helper functions are available when the activator is called standalone.
+        if ( ! function_exists( 'kb_fp_create_default_options' ) ) {
+            require_once KB_FP_PLUGIN_DIR . 'includes/functions-kb-helpers.php';
+        }
+
+        kb_fp_create_default_options();
+        kb_fp_create_custom_tables();
+    }
+}
+

--- a/kb-foreningsportal/includes/class-kb-admins.php
+++ b/kb-foreningsportal/includes/class-kb-admins.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Admin logic and endpoints.
+ */
+class KB_FP_Admins extends KB_FP_REST_Controller {
+    protected $resource     = 'admins';
+    protected $feature_flag = 'features.admins.enabled';
+
+    protected function get_mock_response() {
+        return array(
+            array(
+                'id'          => 1,
+                'name'        => 'Demo Admin',
+                'email'       => 'admin@example.com',
+                'commission'  => array(
+                    'model' => 'flat',
+                    'value' => 0,
+                ),
+                'featureFlag' => $this->feature_flag,
+            ),
+        );
+    }
+}
+

--- a/kb-foreningsportal/includes/class-kb-campaigns.php
+++ b/kb-foreningsportal/includes/class-kb-campaigns.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Campaign logic and endpoints.
+ */
+class KB_FP_Campaigns extends KB_FP_REST_Controller {
+    protected $resource     = 'campaigns';
+    protected $feature_flag = 'features.campaigns.enabled';
+
+    protected function get_mock_response() {
+        return array(
+            array(
+                'id'          => 1,
+                'org_id'      => 1,
+                'name'        => 'Standardkampanj',
+                'status'      => 'draft',
+                'start_date'  => null,
+                'end_date'    => null,
+                'featureFlag' => $this->feature_flag,
+            ),
+        );
+    }
+}
+

--- a/kb-foreningsportal/includes/class-kb-deactivator.php
+++ b/kb-foreningsportal/includes/class-kb-deactivator.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Fired during plugin deactivation.
+ */
+class KB_FP_Deactivator {
+    public static function deactivate() {
+        // Optional: clean up temporary options or caches.
+    }
+}
+

--- a/kb-foreningsportal/includes/class-kb-loader.php
+++ b/kb-foreningsportal/includes/class-kb-loader.php
@@ -16,6 +16,9 @@ class KB_FP_Loader {
     public function __construct() {
         require_once KB_FP_PLUGIN_DIR . 'includes/functions-kb-helpers.php';
         require_once KB_FP_PLUGIN_DIR . 'includes/functions-kb-hooks.php';
+        if ( ! class_exists( 'WP_REST_Controller' ) && file_exists( ABSPATH . 'wp-includes/rest-api/endpoints/class-wp-rest-controller.php' ) ) {
+            require_once ABSPATH . 'wp-includes/rest-api/endpoints/class-wp-rest-controller.php';
+        }
         require_once KB_FP_PLUGIN_DIR . 'includes/class-kb-rest-controller.php';
         require_once KB_FP_PLUGIN_DIR . 'includes/class-kb-orgs.php';
         require_once KB_FP_PLUGIN_DIR . 'includes/class-kb-admins.php';
@@ -33,10 +36,12 @@ class KB_FP_Loader {
 
     public function run() {
         $this->register_modules();
-        $this->admin_ui = new KB_FP_Admin_UI( $this->modules );
+        if ( is_admin() ) {
+            $this->admin_ui = new KB_FP_Admin_UI( $this->modules );
+        }
         $this->public_ui = new KB_FP_Public();
 
-        add_action( 'init', array( $this, 'register_rest_controllers' ) );
+        add_action( 'rest_api_init', array( $this, 'register_rest_controllers' ) );
         add_action( 'init', array( $this, 'register_shortcodes' ) );
         kb_fp_register_common_hooks();
     }

--- a/kb-foreningsportal/includes/class-kb-loader.php
+++ b/kb-foreningsportal/includes/class-kb-loader.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Main loader that wires up admin/public hooks and module registration.
+ */
+class KB_FP_Loader {
+
+    /** @var KB_FP_Admin_UI */
+    protected $admin_ui;
+
+    /** @var KB_FP_Public */
+    protected $public_ui;
+
+    /** @var array */
+    protected $modules = array();
+
+    public function __construct() {
+        require_once KB_FP_PLUGIN_DIR . 'includes/functions-kb-helpers.php';
+        require_once KB_FP_PLUGIN_DIR . 'includes/functions-kb-hooks.php';
+        require_once KB_FP_PLUGIN_DIR . 'includes/class-kb-rest-controller.php';
+        require_once KB_FP_PLUGIN_DIR . 'includes/class-kb-orgs.php';
+        require_once KB_FP_PLUGIN_DIR . 'includes/class-kb-admins.php';
+        require_once KB_FP_PLUGIN_DIR . 'includes/class-kb-campaigns.php';
+        require_once KB_FP_PLUGIN_DIR . 'includes/class-kb-provision.php';
+        require_once KB_FP_PLUGIN_DIR . 'includes/class-kb-orders.php';
+        require_once KB_FP_PLUGIN_DIR . 'includes/class-kb-members.php';
+        require_once KB_FP_PLUGIN_DIR . 'includes/class-kb-material.php';
+        require_once KB_FP_PLUGIN_DIR . 'includes/class-kb-qr.php';
+        require_once KB_FP_PLUGIN_DIR . 'includes/class-kb-logs.php';
+        require_once KB_FP_PLUGIN_DIR . 'includes/class-kb-notifications.php';
+        require_once KB_FP_PLUGIN_DIR . 'admin/class-kb-admin-ui.php';
+        require_once KB_FP_PLUGIN_DIR . 'public/class-kb-public.php';
+    }
+
+    public function run() {
+        $this->register_modules();
+        $this->admin_ui = new KB_FP_Admin_UI( $this->modules );
+        $this->public_ui = new KB_FP_Public();
+
+        add_action( 'init', array( $this, 'register_rest_controllers' ) );
+        add_action( 'init', array( $this, 'register_shortcodes' ) );
+        kb_fp_register_common_hooks();
+    }
+
+    protected function register_modules() {
+        $this->modules = array(
+            'orgs'          => array(
+                'instance'     => new KB_FP_Orgs(),
+                'label'        => __( 'Föreningar', 'kb-foreningsportal' ),
+                'description'  => __( 'Hanterar föreningarnas grunddata, länkar och kopplingar.', 'kb-foreningsportal' ),
+                'feature_flag' => 'features.orgs.enabled',
+                'depends_on'   => array(),
+            ),
+            'admins'        => array(
+                'instance'     => new KB_FP_Admins(),
+                'label'        => __( 'Admins', 'kb-foreningsportal' ),
+                'description'  => __( 'Provisioner och behörigheter för administratörer.', 'kb-foreningsportal' ),
+                'feature_flag' => 'features.admins.enabled',
+                'depends_on'   => array(),
+            ),
+            'campaigns'     => array(
+                'instance'     => new KB_FP_Campaigns(),
+                'label'        => __( 'Kampanjer', 'kb-foreningsportal' ),
+                'description'  => __( 'Standardkampanjer, datum och status för säljrundor.', 'kb-foreningsportal' ),
+                'feature_flag' => 'features.campaigns.enabled',
+                'depends_on'   => array( 'orgs' ),
+            ),
+            'provision'     => array(
+                'instance'     => new KB_FP_Provision(),
+                'label'        => __( 'Provision', 'kb-foreningsportal' ),
+                'description'  => __( 'Provision per box för förening samt adminmodeller.', 'kb-foreningsportal' ),
+                'feature_flag' => 'features.provision.enabled',
+                'depends_on'   => array( 'orgs', 'admins', 'campaigns' ),
+            ),
+            'orders'        => array(
+                'instance'     => new KB_FP_Orders(),
+                'label'        => __( 'Orderkoppling', 'kb-foreningsportal' ),
+                'description'  => __( 'Kopplar WooCommerce-ordrar till förening och admin.', 'kb-foreningsportal' ),
+                'feature_flag' => 'features.orders.enabled',
+                'depends_on'   => array( 'orgs', 'campaigns', 'provision' ),
+            ),
+            'members'       => array(
+                'instance'     => new KB_FP_Members(),
+                'label'        => __( 'Medlemmar', 'kb-foreningsportal' ),
+                'description'  => __( 'Medlemshantering, statistik och export.', 'kb-foreningsportal' ),
+                'feature_flag' => 'features.members.enabled',
+                'depends_on'   => array( 'orgs', 'campaigns' ),
+            ),
+            'material'      => array(
+                'instance'     => new KB_FP_Material(),
+                'label'        => __( 'Material', 'kb-foreningsportal' ),
+                'description'  => __( 'Affischer, flyers, SoMe-texter och genererade filer.', 'kb-foreningsportal' ),
+                'feature_flag' => 'features.materials.enabled',
+                'depends_on'   => array( 'orgs', 'qr' ),
+            ),
+            'qr'            => array(
+                'instance'     => new KB_FP_QR(),
+                'label'        => __( 'QR-koder', 'kb-foreningsportal' ),
+                'description'  => __( 'Auto-generering av QR-koder och föreningslänkar.', 'kb-foreningsportal' ),
+                'feature_flag' => 'features.qr.auto_generate',
+                'depends_on'   => array( 'orgs' ),
+            ),
+            'logs'          => array(
+                'instance'     => new KB_FP_Logs(),
+                'label'        => __( 'Loggar', 'kb-foreningsportal' ),
+                'description'  => __( 'Ändringslogg, diagnostik och händelser.', 'kb-foreningsportal' ),
+                'feature_flag' => 'features.logs.enabled',
+                'depends_on'   => array(),
+            ),
+            'notifications' => array(
+                'instance'     => new KB_FP_Notifications(),
+                'label'        => __( 'Notiser', 'kb-foreningsportal' ),
+                'description'  => __( 'Systemnotiser och larm för viktiga händelser.', 'kb-foreningsportal' ),
+                'feature_flag' => 'features.notifications.enabled',
+                'depends_on'   => array( 'logs' ),
+            ),
+        );
+    }
+
+    public function register_rest_controllers() {
+        foreach ( $this->modules as $module ) {
+            if ( ! isset( $module['instance'] ) ) {
+                continue;
+            }
+
+            $flag = isset( $module['feature_flag'] ) ? $module['feature_flag'] : $module['instance']->get_feature_flag();
+
+            if ( method_exists( $module['instance'], 'register_routes' ) && kb_fp_is_feature_enabled( $flag ) ) {
+                $module['instance']->register_routes();
+            }
+        }
+    }
+
+    public function register_shortcodes() {
+        $this->public_ui->register_shortcodes();
+    }
+}
+

--- a/kb-foreningsportal/includes/class-kb-logs.php
+++ b/kb-foreningsportal/includes/class-kb-logs.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Logging and diagnostics.
+ */
+class KB_FP_Logs extends KB_FP_REST_Controller {
+    protected $resource     = 'logs';
+    protected $feature_flag = 'features.logs.enabled';
+
+    protected function get_mock_response() {
+        return array(
+            array(
+                'id'          => 1,
+                'message'     => 'Loggning initierad.',
+                'created_at'  => current_time( 'mysql' ),
+                'featureFlag' => $this->feature_flag,
+            ),
+        );
+    }
+}
+

--- a/kb-foreningsportal/includes/class-kb-material.php
+++ b/kb-foreningsportal/includes/class-kb-material.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Material generation and storage.
+ */
+class KB_FP_Material extends KB_FP_REST_Controller {
+    protected $resource     = 'materials';
+    protected $feature_flag = 'features.materials.enabled';
+
+    protected function get_mock_response() {
+        return array(
+            array(
+                'id'          => 1,
+                'org_id'      => 1,
+                'type'        => 'flyer',
+                'url'         => 'https://example.com/flyer.pdf',
+                'featureFlag' => $this->feature_flag,
+            ),
+        );
+    }
+}
+

--- a/kb-foreningsportal/includes/class-kb-members.php
+++ b/kb-foreningsportal/includes/class-kb-members.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Member management.
+ */
+class KB_FP_Members extends KB_FP_REST_Controller {
+    protected $resource     = 'members';
+    protected $feature_flag = 'features.members.enabled';
+
+    protected function get_mock_response() {
+        return array(
+            array(
+                'id'          => 1,
+                'org_id'      => 1,
+                'name'        => 'Demo Medlem',
+                'email'       => 'member@example.com',
+                'featureFlag' => $this->feature_flag,
+            ),
+        );
+    }
+}
+

--- a/kb-foreningsportal/includes/class-kb-notifications.php
+++ b/kb-foreningsportal/includes/class-kb-notifications.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Internal notifications.
+ */
+class KB_FP_Notifications extends KB_FP_REST_Controller {
+    protected $resource     = 'notifications';
+    protected $feature_flag = 'features.notifications.enabled';
+
+    protected function get_mock_response() {
+        return array(
+            array(
+                'id'          => 1,
+                'type'        => 'info',
+                'message'     => 'Systemet är igång.',
+                'created_at'  => current_time( 'mysql' ),
+                'featureFlag' => $this->feature_flag,
+            ),
+        );
+    }
+}
+

--- a/kb-foreningsportal/includes/class-kb-orders.php
+++ b/kb-foreningsportal/includes/class-kb-orders.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Order linkage to campaigns/orgs.
+ */
+class KB_FP_Orders extends KB_FP_REST_Controller {
+    protected $resource     = 'orders';
+    protected $feature_flag = 'features.orders.enabled';
+
+    protected function get_mock_response() {
+        return array(
+            array(
+                'id'          => 1001,
+                'org_id'      => 1,
+                'admin_id'    => null,
+                'status'      => 'pending',
+                'synced'      => false,
+                'featureFlag' => $this->feature_flag,
+            ),
+        );
+    }
+}
+

--- a/kb-foreningsportal/includes/class-kb-orgs.php
+++ b/kb-foreningsportal/includes/class-kb-orgs.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Organisation logic and endpoints.
+ */
+class KB_FP_Orgs extends KB_FP_REST_Controller {
+    protected $resource     = 'orgs';
+    protected $feature_flag = 'features.orgs.enabled';
+
+    protected function get_mock_response() {
+        return array(
+            array(
+                'id'          => 1,
+                'name'        => 'Exempelförening',
+                'campaigns'   => 0,
+                'provision'   => 0,
+                'status'      => 'draft',
+                'featureFlag' => $this->feature_flag,
+            ),
+        );
+    }
+}
+

--- a/kb-foreningsportal/includes/class-kb-provision.php
+++ b/kb-foreningsportal/includes/class-kb-provision.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Provision logic and endpoints.
+ */
+class KB_FP_Provision extends KB_FP_REST_Controller {
+    protected $resource     = 'provision';
+    protected $feature_flag = 'features.provision.enabled';
+
+    protected function get_mock_response() {
+        return array(
+            'org'   => array( 'per_box' => 0 ),
+            'admin' => array(
+                'model' => 'flat',
+                'value' => 0,
+            ),
+            'featureFlag' => $this->feature_flag,
+        );
+    }
+}
+

--- a/kb-foreningsportal/includes/class-kb-qr.php
+++ b/kb-foreningsportal/includes/class-kb-qr.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * QR generation.
+ */
+class KB_FP_QR extends KB_FP_REST_Controller {
+    protected $resource     = 'qr';
+    protected $feature_flag = 'features.qr.auto_generate';
+
+    protected function get_mock_response() {
+        return array(
+            array(
+                'id'          => 1,
+                'org_id'      => 1,
+                'code'        => 'QR123',
+                'url'         => 'https://example.com/org/qr123',
+                'featureFlag' => $this->feature_flag,
+            ),
+        );
+    }
+}
+

--- a/kb-foreningsportal/includes/class-kb-rest-controller.php
+++ b/kb-foreningsportal/includes/class-kb-rest-controller.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Base REST controller for KB Föreningsportal.
+ */
+abstract class KB_FP_REST_Controller extends WP_REST_Controller {
+
+    /** @var string */
+    protected $resource = '';
+
+    /** @var string */
+    protected $feature_flag = '';
+
+    public function __construct() {
+        $this->namespace = 'kb-forening/v1';
+    }
+
+    public function permission_callback( WP_REST_Request $request ) {
+        return current_user_can( 'manage_options' );
+    }
+
+    public function register_routes() {
+        if ( empty( $this->resource ) ) {
+            return;
+        }
+
+        register_rest_route( $this->get_namespace(), '/' . $this->resource, array(
+            array(
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => array( $this, 'get_items' ),
+                'permission_callback' => array( $this, 'permission_callback' ),
+            ),
+        ) );
+    }
+
+    public function get_items( WP_REST_Request $request ) {
+        return rest_ensure_response( $this->get_mock_response() );
+    }
+
+    public function get_feature_flag() {
+        return $this->feature_flag;
+    }
+
+    protected function get_mock_response() {
+        return array(
+            'resource' => $this->resource,
+            'items'    => array(),
+        );
+    }
+
+    protected function get_namespace() {
+        return $this->namespace;
+    }
+}
+

--- a/kb-foreningsportal/includes/functions-kb-helpers.php
+++ b/kb-foreningsportal/includes/functions-kb-helpers.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Helper functions for KB Föreningsportal.
+ */
+
+function kb_fp_is_feature_enabled( $flag ) {
+    $options = kb_fp_get_feature_options();
+    return isset( $options[ $flag ] ) ? (bool) $options[ $flag ] : true;
+}
+
+function kb_fp_get_feature_defaults( $modules = array() ) {
+    $defaults = array(
+        'features.orgs.enabled'                   => true,
+        'features.admins.enabled'                 => true,
+        'features.campaigns.enabled'              => true,
+        'features.provision.enabled'              => true,
+        'features.orders.enabled'                 => true,
+        'features.members.enabled'                => false,
+        'features.materials.enabled'              => true,
+        'features.qr.auto_generate'               => true,
+        'features.logs.enabled'                   => true,
+        'features.notifications.enabled'          => true,
+        'features.materials.auto_generate_on_org_create' => true,
+        'features.email.automated_campaign_mails'        => true,
+        'features.admin_commission.enabled'               => true,
+        'features.stats.advanced_graphs'                  => true,
+        'features.support.diagnostics'                    => true,
+        'features.security.rate_limit_public'             => true,
+    );
+
+    foreach ( $modules as $module ) {
+        if ( isset( $module['feature_flag'] ) && ! isset( $defaults[ $module['feature_flag'] ] ) ) {
+            $defaults[ $module['feature_flag'] ] = true;
+        }
+    }
+
+    return $defaults;
+}
+
+function kb_fp_get_feature_options( $modules = array() ) {
+    $defaults = kb_fp_get_feature_defaults( $modules );
+    $options  = get_option( 'kb_fp_features', array() );
+    $sanitized = array();
+
+    foreach ( $defaults as $key => $default ) {
+        $sanitized[ $key ] = isset( $options[ $key ] ) ? (bool) $options[ $key ] : (bool) $default;
+    }
+
+    return $sanitized;
+}
+
+function kb_fp_sanitize_features( $input ) {
+    $input = is_array( $input ) ? $input : array();
+    $clean = array();
+
+    foreach ( $input as $key => $value ) {
+        $clean[ $key ] = (bool) $value;
+    }
+
+    return $clean;
+}
+
+function kb_fp_create_default_options( $modules = array() ) {
+    $defaults = kb_fp_get_feature_defaults( $modules );
+    add_option( 'kb_fp_features', $defaults );
+}
+
+function kb_fp_create_custom_tables() {
+    global $wpdb;
+    $charset_collate = $wpdb->get_charset_collate();
+    // Placeholder for actual schema creation.
+    $tables = array(
+        'kb_orgs'                => "CREATE TABLE {$wpdb->prefix}kb_orgs (id BIGINT unsigned NOT NULL AUTO_INCREMENT, name varchar(255) NOT NULL, PRIMARY KEY (id)) $charset_collate;",
+        'kb_admins'              => "CREATE TABLE {$wpdb->prefix}kb_admins (id BIGINT unsigned NOT NULL AUTO_INCREMENT, name varchar(255) NOT NULL, PRIMARY KEY (id)) $charset_collate;",
+        'kb_campaigns'           => "CREATE TABLE {$wpdb->prefix}kb_campaigns (id BIGINT unsigned NOT NULL AUTO_INCREMENT, org_id BIGINT unsigned NOT NULL, PRIMARY KEY (id)) $charset_collate;",
+        'kb_org_provision'       => "CREATE TABLE {$wpdb->prefix}kb_org_provision (id BIGINT unsigned NOT NULL AUTO_INCREMENT, org_id BIGINT unsigned NOT NULL, amount decimal(10,2) NOT NULL DEFAULT 0, PRIMARY KEY (id)) $charset_collate;",
+        'kb_order_link'          => "CREATE TABLE {$wpdb->prefix}kb_order_link (id BIGINT unsigned NOT NULL AUTO_INCREMENT, order_id BIGINT unsigned NOT NULL, org_id BIGINT unsigned NOT NULL, PRIMARY KEY (id)) $charset_collate;",
+        'kb_members'             => "CREATE TABLE {$wpdb->prefix}kb_members (id BIGINT unsigned NOT NULL AUTO_INCREMENT, org_id BIGINT unsigned NOT NULL, email varchar(255), PRIMARY KEY (id)) $charset_collate;",
+        'kb_sales_aggregates'    => "CREATE TABLE {$wpdb->prefix}kb_sales_aggregates (id BIGINT unsigned NOT NULL AUTO_INCREMENT, org_id BIGINT unsigned NOT NULL, total decimal(10,2), PRIMARY KEY (id)) $charset_collate;",
+        'kb_admin_commissions'   => "CREATE TABLE {$wpdb->prefix}kb_admin_commissions (id BIGINT unsigned NOT NULL AUTO_INCREMENT, admin_id BIGINT unsigned NOT NULL, total decimal(10,2), PRIMARY KEY (id)) $charset_collate;",
+        'kb_material_templates'  => "CREATE TABLE {$wpdb->prefix}kb_material_templates (id BIGINT unsigned NOT NULL AUTO_INCREMENT, name varchar(255), PRIMARY KEY (id)) $charset_collate;",
+        'kb_generated_material'  => "CREATE TABLE {$wpdb->prefix}kb_generated_material (id BIGINT unsigned NOT NULL AUTO_INCREMENT, org_id BIGINT unsigned NOT NULL, url text, PRIMARY KEY (id)) $charset_collate;",
+        'kb_qr_codes'            => "CREATE TABLE {$wpdb->prefix}kb_qr_codes (id BIGINT unsigned NOT NULL AUTO_INCREMENT, org_id BIGINT unsigned NOT NULL, code varchar(255), PRIMARY KEY (id)) $charset_collate;",
+        'kb_logs'                => "CREATE TABLE {$wpdb->prefix}kb_logs (id BIGINT unsigned NOT NULL AUTO_INCREMENT, message text, created_at datetime DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (id)) $charset_collate;",
+        'kb_notifications'       => "CREATE TABLE {$wpdb->prefix}kb_notifications (id BIGINT unsigned NOT NULL AUTO_INCREMENT, type varchar(50), payload text, created_at datetime DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (id)) $charset_collate;",
+    );
+
+    require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+    foreach ( $tables as $sql ) {
+        dbDelta( $sql );
+    }
+}
+

--- a/kb-foreningsportal/includes/functions-kb-hooks.php
+++ b/kb-foreningsportal/includes/functions-kb-hooks.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Common WordPress hooks for the plugin.
+ */
+
+function kb_fp_register_common_hooks() {
+    add_action( 'rest_api_init', 'kb_fp_register_diagnostics' );
+}
+
+function kb_fp_register_diagnostics() {
+    register_rest_route( 'kb-forening/v1', '/health', array(
+        'methods'             => WP_REST_Server::READABLE,
+        'callback'            => function () {
+            return rest_ensure_response( array( 'status' => 'ok' ) );
+        },
+        'permission_callback' => '__return_true',
+    ) );
+}
+

--- a/kb-foreningsportal/kb-foreningsportal.php
+++ b/kb-foreningsportal/kb-foreningsportal.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Plugin Name: KB Föreningsportal
+ * Description: Modular föreningsportal för Kryddbox med React-frontend och REST-API.
+ * Version: 0.1.0
+ * Author: Team Nattum
+ * License: GPL2+
+ */
+
+if ( ! defined( 'WPINC' ) ) {
+    die;
+}
+
+// Plugin constants.
+define( 'KB_FP_VERSION', '0.1.0' );
+define( 'KB_FP_PLUGIN_FILE', __FILE__ );
+define( 'KB_FP_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'KB_FP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+// Shared helpers must be available for activation callbacks.
+require_once KB_FP_PLUGIN_DIR . 'includes/functions-kb-helpers.php';
+
+// Autoload core files.
+require_once KB_FP_PLUGIN_DIR . 'includes/class-kb-loader.php';
+require_once KB_FP_PLUGIN_DIR . 'includes/class-kb-activator.php';
+require_once KB_FP_PLUGIN_DIR . 'includes/class-kb-deactivator.php';
+
+register_activation_hook( __FILE__, array( 'KB_FP_Activator', 'activate' ) );
+register_deactivation_hook( __FILE__, array( 'KB_FP_Deactivator', 'deactivate' ) );
+
+/**
+ * Begins execution of the plugin.
+ */
+function run_kb_foreningsportal() {
+    $loader = new KB_FP_Loader();
+    $loader->run();
+}
+run_kb_foreningsportal();
+

--- a/kb-foreningsportal/public/class-kb-public.php
+++ b/kb-foreningsportal/public/class-kb-public.php
@@ -10,11 +10,19 @@ class KB_FP_Public {
 
     public function render_portal_root( $atts ) {
         $atts = shortcode_atts( array( 'mode' => 'org' ), $atts );
+        $this->enqueue_assets( $atts['mode'] );
         ob_start();
         ?>
         <div id="kb-portal-root" data-mode="<?php echo esc_attr( $atts['mode'] ); ?>"></div>
         <?php
         return ob_get_clean();
+    }
+
+    protected function enqueue_assets( $mode ) {
+        wp_enqueue_style( 'kb-fp-portal', KB_FP_PLUGIN_URL . 'assets/css/portal.css', array(), KB_FP_VERSION );
+
+        $script = 'admin' === $mode ? 'assets/js/portal-admin.bundle.js' : 'assets/js/portal-org.bundle.js';
+        wp_enqueue_script( 'kb-fp-portal', KB_FP_PLUGIN_URL . $script, array(), KB_FP_VERSION, true );
     }
 }
 

--- a/kb-foreningsportal/public/class-kb-public.php
+++ b/kb-foreningsportal/public/class-kb-public.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Public-facing hooks and shortcodes.
+ */
+class KB_FP_Public {
+
+    public function register_shortcodes() {
+        add_shortcode( 'kb_foreningsportal', array( $this, 'render_portal_root' ) );
+    }
+
+    public function render_portal_root( $atts ) {
+        $atts = shortcode_atts( array( 'mode' => 'org' ), $atts );
+        ob_start();
+        ?>
+        <div id="kb-portal-root" data-mode="<?php echo esc_attr( $atts['mode'] ); ?>"></div>
+        <?php
+        return ob_get_clean();
+    }
+}
+

--- a/kb-foreningsportal/react-app/README.md
+++ b/kb-foreningsportal/react-app/README.md
@@ -1,0 +1,3 @@
+# KB Föreningsportal React-app
+
+Plats för React-koden till admin- och föreningsportalerna. Byggresultatet ska läggas i `../assets/js` och `../assets/css`.

--- a/kb-foreningsportal/react-app/package.json
+++ b/kb-foreningsportal/react-app/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "kb-foreningsportal",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "echo 'Add linting as needed'"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.2",
+    "typescript": "^5.3.3",
+    "vite": "^5.2.0"
+  }
+}

--- a/kb-foreningsportal/react-app/public/index.html
+++ b/kb-foreningsportal/react-app/public/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="sv">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>KB Föreningsportal</title>
+  </head>
+  <body>
+    <div id="kb-portal-root" data-mode="org"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/kb-foreningsportal/react-app/src/App.tsx
+++ b/kb-foreningsportal/react-app/src/App.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import AdminLayout from './components/layout/AdminLayout';
+import OrgLayout from './components/layout/OrgLayout';
+import AdminDashboardPage from './pages/admin/AdminDashboardPage';
+import AdminOrgsPage from './pages/admin/AdminOrgsPage';
+import AdminOrgDetailPage from './pages/admin/AdminOrgDetailPage';
+import AdminAdminsPage from './pages/admin/AdminAdminsPage';
+import AdminReportsPage from './pages/admin/AdminReportsPage';
+import AdminSettingsPage from './pages/admin/AdminSettingsPage';
+import OrgDashboardPage from './pages/org/OrgDashboardPage';
+import OrgMembersPage from './pages/org/OrgMembersPage';
+import OrgMaterialsPage from './pages/org/OrgMaterialsPage';
+import OrgCampaignPage from './pages/org/OrgCampaignPage';
+
+export type PortalMode = 'admin' | 'org';
+
+type AppProps = {
+  mode: PortalMode;
+};
+
+const App: React.FC<AppProps> = ({ mode }) => {
+  if (mode === 'admin') {
+    return (
+      <AdminLayout
+        pages={[
+          { id: 'admin-dashboard', title: 'Dashboard', element: <AdminDashboardPage /> },
+          { id: 'admin-orgs', title: 'Föreningar', element: <AdminOrgsPage /> },
+          { id: 'admin-org-detail', title: 'Föreningsdetaljer', element: <AdminOrgDetailPage /> },
+          { id: 'admin-admins', title: 'Admins', element: <AdminAdminsPage /> },
+          { id: 'admin-reports', title: 'Rapporter', element: <AdminReportsPage /> },
+          { id: 'admin-settings', title: 'Inställningar', element: <AdminSettingsPage /> },
+        ]}
+      />
+    );
+  }
+
+  return (
+    <OrgLayout
+      pages={[
+        { id: 'org-dashboard', title: 'Dashboard', element: <OrgDashboardPage /> },
+        { id: 'org-members', title: 'Medlemmar', element: <OrgMembersPage /> },
+        { id: 'org-materials', title: 'Material', element: <OrgMaterialsPage /> },
+        { id: 'org-campaign', title: 'Kampanj', element: <OrgCampaignPage /> },
+      ]}
+    />
+  );
+};
+
+export default App;

--- a/kb-foreningsportal/react-app/src/api/admins.ts
+++ b/kb-foreningsportal/react-app/src/api/admins.ts
@@ -1,0 +1,11 @@
+import { apiClient } from './client';
+
+export type Admin = {
+  id: number;
+  name: string;
+  commission_model: string;
+};
+
+export function fetchAdmins() {
+  return apiClient.get<Admin[]>('/admins');
+}

--- a/kb-foreningsportal/react-app/src/api/auth.ts
+++ b/kb-foreningsportal/react-app/src/api/auth.ts
@@ -1,0 +1,5 @@
+export function getPortalModeFromDataset(): 'admin' | 'org' {
+  const container = document.getElementById('kb-portal-root');
+  const mode = container?.getAttribute('data-mode');
+  return mode === 'admin' ? 'admin' : 'org';
+}

--- a/kb-foreningsportal/react-app/src/api/campaigns.ts
+++ b/kb-foreningsportal/react-app/src/api/campaigns.ts
@@ -1,0 +1,11 @@
+import { apiClient } from './client';
+
+export type Campaign = {
+  id: number;
+  name: string;
+  status: string;
+};
+
+export function fetchCampaigns() {
+  return apiClient.get<Campaign[]>('/campaigns');
+}

--- a/kb-foreningsportal/react-app/src/api/client.ts
+++ b/kb-foreningsportal/react-app/src/api/client.ts
@@ -1,0 +1,19 @@
+export const apiBase = '/wp-json/kb-forening/v1';
+
+async function request<T>(url: string, options?: RequestInit): Promise<T> {
+  const response = await fetch(url, {
+    headers: { 'Content-Type': 'application/json' },
+    ...options,
+  });
+
+  if (!response.ok) {
+    throw new Error(`API error ${response.status}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export const apiClient = {
+  get: <T>(path: string) => request<T>(`${apiBase}${path}`),
+  post: <T>(path: string, body: unknown) => request<T>(`${apiBase}${path}`, { method: 'POST', body: JSON.stringify(body) }),
+};

--- a/kb-foreningsportal/react-app/src/api/materials.ts
+++ b/kb-foreningsportal/react-app/src/api/materials.ts
@@ -1,0 +1,11 @@
+import { apiClient } from './client';
+
+export type Material = {
+  id: number;
+  title: string;
+  url: string;
+};
+
+export function fetchMaterials(orgId: number) {
+  return apiClient.get<Material[]>(`/materials?org=${orgId}`);
+}

--- a/kb-foreningsportal/react-app/src/api/orgs.ts
+++ b/kb-foreningsportal/react-app/src/api/orgs.ts
@@ -1,0 +1,10 @@
+import { apiClient } from './client';
+
+export type Org = {
+  id: number;
+  name: string;
+};
+
+export function fetchOrgs() {
+  return apiClient.get<Org[]>('/orgs');
+}

--- a/kb-foreningsportal/react-app/src/api/stats.ts
+++ b/kb-foreningsportal/react-app/src/api/stats.ts
@@ -1,0 +1,10 @@
+import { apiClient } from './client';
+
+export type StatsSummary = {
+  sales: number;
+  commission: number;
+};
+
+export function fetchStatsSummary() {
+  return apiClient.get<StatsSummary>('/stats/summary');
+}

--- a/kb-foreningsportal/react-app/src/components/charts/SalesChart.tsx
+++ b/kb-foreningsportal/react-app/src/components/charts/SalesChart.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import Card from '../ui/Card';
+
+const SalesChart: React.FC = () => {
+  return (
+    <Card title="Försäljning över tid">
+      <div className="kb-chart__placeholder">Diagram kommer här (mockdata).</div>
+    </Card>
+  );
+};
+
+export default SalesChart;

--- a/kb-foreningsportal/react-app/src/components/diagnostics/DiagnosticsPanel.tsx
+++ b/kb-foreningsportal/react-app/src/components/diagnostics/DiagnosticsPanel.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import Card from '../ui/Card';
+import Button from '../ui/Button';
+
+type DiagnosticsPanelProps = {
+  issues: { id: string; message: string; suggestion?: string }[];
+};
+
+const DiagnosticsPanel: React.FC<DiagnosticsPanelProps> = ({ issues }) => (
+  <Card title="Diagnostik">
+    {issues.length === 0 && <p>Inga kända problem.</p>}
+    <ul className="kb-list">
+      {issues.map((issue) => (
+        <li key={issue.id} className="kb-list__item">
+          <div>
+            <strong>{issue.message}</strong>
+            {issue.suggestion && <p className="kb-list__hint">{issue.suggestion}</p>}
+          </div>
+          <Button variant="secondary">Åtgärda</Button>
+        </li>
+      ))}
+    </ul>
+  </Card>
+);
+
+export default DiagnosticsPanel;

--- a/kb-foreningsportal/react-app/src/components/layout/AdminLayout.tsx
+++ b/kb-foreningsportal/react-app/src/components/layout/AdminLayout.tsx
@@ -1,0 +1,32 @@
+import React, { useMemo, useState } from 'react';
+import NavBar from './NavBar';
+import { PageConfig } from '../../types';
+import Card from '../ui/Card';
+
+type AdminLayoutProps = {
+  pages: PageConfig[];
+};
+
+const AdminLayout: React.FC<AdminLayoutProps> = ({ pages }) => {
+  const [activePageId, setActivePageId] = useState(pages[0]?.id ?? '');
+
+  const ActivePage = useMemo(() => pages.find((p) => p.id === activePageId)?.element, [activePageId, pages]);
+
+  return (
+    <div className="kb-layout">
+      <NavBar
+        title="KB Adminportal"
+        items={pages.map((page) => ({ id: page.id, label: page.title }))}
+        activeId={activePageId}
+        onNavigate={setActivePageId}
+      />
+      <main className="kb-content">
+        <Card>
+          {ActivePage ?? <p>Ingen sida vald.</p>}
+        </Card>
+      </main>
+    </div>
+  );
+};
+
+export default AdminLayout;

--- a/kb-foreningsportal/react-app/src/components/layout/NavBar.tsx
+++ b/kb-foreningsportal/react-app/src/components/layout/NavBar.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import Button from '../ui/Button';
+
+type NavItem = {
+  id: string;
+  label: string;
+};
+
+type NavBarProps = {
+  title: string;
+  items: NavItem[];
+  activeId: string;
+  onNavigate: (id: string) => void;
+};
+
+const NavBar: React.FC<NavBarProps> = ({ title, items, activeId, onNavigate }) => {
+  return (
+    <header className="kb-navbar">
+      <div className="kb-navbar__brand">{title}</div>
+      <nav className="kb-navbar__nav">
+        {items.map((item) => (
+          <Button
+            key={item.id}
+            variant={item.id === activeId ? 'primary' : 'ghost'}
+            onClick={() => onNavigate(item.id)}
+          >
+            {item.label}
+          </Button>
+        ))}
+      </nav>
+    </header>
+  );
+};
+
+export default NavBar;

--- a/kb-foreningsportal/react-app/src/components/layout/OrgLayout.tsx
+++ b/kb-foreningsportal/react-app/src/components/layout/OrgLayout.tsx
@@ -1,0 +1,31 @@
+import React, { useMemo, useState } from 'react';
+import NavBar from './NavBar';
+import { PageConfig } from '../../types';
+import Card from '../ui/Card';
+
+type OrgLayoutProps = {
+  pages: PageConfig[];
+};
+
+const OrgLayout: React.FC<OrgLayoutProps> = ({ pages }) => {
+  const [activePageId, setActivePageId] = useState(pages[0]?.id ?? '');
+  const ActivePage = useMemo(() => pages.find((p) => p.id === activePageId)?.element, [activePageId, pages]);
+
+  return (
+    <div className="kb-layout">
+      <NavBar
+        title="Föreningsportal"
+        items={pages.map((page) => ({ id: page.id, label: page.title }))}
+        activeId={activePageId}
+        onNavigate={setActivePageId}
+      />
+      <main className="kb-content">
+        <Card>
+          {ActivePage ?? <p>Ingen sida vald.</p>}
+        </Card>
+      </main>
+    </div>
+  );
+};
+
+export default OrgLayout;

--- a/kb-foreningsportal/react-app/src/components/qr/QRCard.tsx
+++ b/kb-foreningsportal/react-app/src/components/qr/QRCard.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Card from '../ui/Card';
+import Button from '../ui/Button';
+
+type QRCardProps = {
+  link: string;
+  code: string;
+};
+
+const QRCard: React.FC<QRCardProps> = ({ link, code }) => {
+  return (
+    <Card title="Föreningslänk och QR">
+      <p><strong>Länk:</strong> {link}</p>
+      <p><strong>Kod:</strong> {code}</p>
+      <div className="kb-qr__actions">
+        <Button variant="secondary">Kopiera länk</Button>
+        <Button variant="ghost">Ladda ned QR</Button>
+      </div>
+    </Card>
+  );
+};
+
+export default QRCard;

--- a/kb-foreningsportal/react-app/src/components/stats/StatsCard.tsx
+++ b/kb-foreningsportal/react-app/src/components/stats/StatsCard.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import Card from '../ui/Card';
+import { StatDatum } from '../../types';
+
+type StatsCardProps = {
+  title: string;
+  stats: StatDatum[];
+};
+
+const StatsCard: React.FC<StatsCardProps> = ({ title, stats }) => (
+  <Card title={title}>
+    <div className="kb-stats">
+      {stats.map((stat) => (
+        <div key={stat.label} className="kb-stats__item">
+          <div className="kb-stats__label">{stat.label}</div>
+          <div className="kb-stats__value">{stat.value}</div>
+          {stat.delta && <div className="kb-stats__delta">{stat.delta}</div>}
+        </div>
+      ))}
+    </div>
+  </Card>
+);
+
+export default StatsCard;

--- a/kb-foreningsportal/react-app/src/components/ui/Button.tsx
+++ b/kb-foreningsportal/react-app/src/components/ui/Button.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: 'primary' | 'secondary' | 'ghost';
+};
+
+const Button: React.FC<ButtonProps> = ({ variant = 'primary', children, ...props }) => {
+  return (
+    <button className={`kb-btn kb-btn--${variant}`} {...props}>
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/kb-foreningsportal/react-app/src/components/ui/Card.tsx
+++ b/kb-foreningsportal/react-app/src/components/ui/Card.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+type CardProps = {
+  title?: string;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+};
+
+const Card: React.FC<CardProps> = ({ title, actions, children }) => {
+  return (
+    <section className="kb-card">
+      {(title || actions) && (
+        <header className="kb-card__header">
+          {title && <h3>{title}</h3>}
+          {actions && <div className="kb-card__actions">{actions}</div>}
+        </header>
+      )}
+      <div className="kb-card__body">{children}</div>
+    </section>
+  );
+};
+
+export default Card;

--- a/kb-foreningsportal/react-app/src/components/ui/Modal.tsx
+++ b/kb-foreningsportal/react-app/src/components/ui/Modal.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import Button from './Button';
+
+type ModalProps = {
+  title: string;
+  open: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+};
+
+const Modal: React.FC<ModalProps> = ({ title, open, onClose, children }) => {
+  if (!open) return null;
+
+  return (
+    <div className="kb-modal__overlay" role="dialog" aria-modal="true" aria-label={title}>
+      <div className="kb-modal">
+        <header className="kb-modal__header">
+          <h3>{title}</h3>
+          <Button variant="ghost" onClick={onClose} aria-label="Stäng">
+            ✕
+          </Button>
+        </header>
+        <div className="kb-modal__body">{children}</div>
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/kb-foreningsportal/react-app/src/components/ui/Table.tsx
+++ b/kb-foreningsportal/react-app/src/components/ui/Table.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { TableColumn, TableRow } from '../../types';
+
+type TableProps<T extends TableRow> = {
+  columns: TableColumn<T>[];
+  data: T[];
+};
+
+const Table = <T extends TableRow>({ columns, data }: TableProps<T>) => (
+  <table className="kb-table">
+    <thead>
+      <tr>
+        {columns.map((col) => (
+          <th key={String(col.accessor)}>{col.header}</th>
+        ))}
+      </tr>
+    </thead>
+    <tbody>
+      {data.map((row, idx) => (
+        <tr key={idx}>
+          {columns.map((col) => (
+            <td key={String(col.accessor)}>{String(row[col.accessor])}</td>
+          ))}
+        </tr>
+      ))}
+    </tbody>
+  </table>
+);
+
+export default Table;

--- a/kb-foreningsportal/react-app/src/context/AuthContext.tsx
+++ b/kb-foreningsportal/react-app/src/context/AuthContext.tsx
@@ -1,0 +1,13 @@
+import React, { createContext, useContext } from 'react';
+import { useAuth } from '../hooks/useAuth';
+
+const AuthContext = createContext<{ role: 'admin' | 'org' }>({ role: 'org' });
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { role } = useAuth();
+  return <AuthContext.Provider value={{ role }}>{children}</AuthContext.Provider>;
+};
+
+export function useAuthContext() {
+  return useContext(AuthContext);
+}

--- a/kb-foreningsportal/react-app/src/context/UiContext.tsx
+++ b/kb-foreningsportal/react-app/src/context/UiContext.tsx
@@ -1,0 +1,17 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const UiContext = createContext<{ sidebarOpen: boolean; toggleSidebar: () => void }>({
+  sidebarOpen: false,
+  toggleSidebar: () => undefined,
+});
+
+export const UiProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const toggleSidebar = () => setSidebarOpen((prev) => !prev);
+
+  return <UiContext.Provider value={{ sidebarOpen, toggleSidebar }}>{children}</UiContext.Provider>;
+};
+
+export function useUi() {
+  return useContext(UiContext);
+}

--- a/kb-foreningsportal/react-app/src/hooks/useAuth.ts
+++ b/kb-foreningsportal/react-app/src/hooks/useAuth.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react';
+import { getPortalModeFromDataset } from '../api/auth';
+
+export function useAuth() {
+  const [role, setRole] = useState<'admin' | 'org'>('org');
+
+  useEffect(() => {
+    setRole(getPortalModeFromDataset());
+  }, []);
+
+  return { role };
+}

--- a/kb-foreningsportal/react-app/src/hooks/useNotifications.ts
+++ b/kb-foreningsportal/react-app/src/hooks/useNotifications.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+export type Notification = {
+  id: string;
+  message: string;
+  level: 'info' | 'warning' | 'error';
+};
+
+export function useNotifications() {
+  const [items, setItems] = useState<Notification[]>([]);
+
+  useEffect(() => {
+    setItems([
+      { id: 'welcome', message: 'Välkommen till KB Föreningsportal!', level: 'info' },
+    ]);
+  }, []);
+
+  return { items };
+}

--- a/kb-foreningsportal/react-app/src/hooks/useOrgStats.ts
+++ b/kb-foreningsportal/react-app/src/hooks/useOrgStats.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+import { fetchStatsSummary, StatsSummary } from '../api/stats';
+
+export function useOrgStats() {
+  const [data, setData] = useState<StatsSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchStatsSummary()
+      .then((stats) => setData(stats))
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return { data, loading, error };
+}

--- a/kb-foreningsportal/react-app/src/index.tsx
+++ b/kb-foreningsportal/react-app/src/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './styles/globals.css';
+import './styles/theme.css';
+
+const container = document.getElementById('kb-portal-root');
+
+if (container) {
+  const mode = container.getAttribute('data-mode') === 'admin' ? 'admin' : 'org';
+  const root = createRoot(container);
+  root.render(<App mode={mode} />);
+}

--- a/kb-foreningsportal/react-app/src/pages/admin/AdminAdminsPage.tsx
+++ b/kb-foreningsportal/react-app/src/pages/admin/AdminAdminsPage.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import Table from '../../components/ui/Table';
+import { TableRow } from '../../types';
+
+const AdminAdminsPage: React.FC = () => {
+  const data: TableRow[] = [
+    { name: 'Anna Admin', commission: '10 kr/box', orgs: 4 },
+    { name: 'Björn Bas', commission: '5% av provision', orgs: 2 },
+  ];
+
+  return (
+    <div>
+      <h2>Admins</h2>
+      <Table
+        columns={[
+          { header: 'Namn', accessor: 'name' },
+          { header: 'Provision', accessor: 'commission' },
+          { header: 'Föreningar', accessor: 'orgs' },
+        ]}
+        data={data}
+      />
+    </div>
+  );
+};
+
+export default AdminAdminsPage;

--- a/kb-foreningsportal/react-app/src/pages/admin/AdminDashboardPage.tsx
+++ b/kb-foreningsportal/react-app/src/pages/admin/AdminDashboardPage.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import StatsCard from '../../components/stats/StatsCard';
+import SalesChart from '../../components/charts/SalesChart';
+import DiagnosticsPanel from '../../components/diagnostics/DiagnosticsPanel';
+
+const AdminDashboardPage: React.FC = () => {
+  return (
+    <div className="kb-grid">
+      <StatsCard
+        title="Snabbstatistik"
+        stats={[
+          { label: 'Sålda boxar', value: 1200, delta: '+12% mot föregående' },
+          { label: 'Aktiva kampanjer', value: 14 },
+          { label: 'Provision att betala', value: '42 000 kr' },
+        ]}
+      />
+      <SalesChart />
+      <DiagnosticsPanel
+        issues={[
+          { id: 'orders', message: '3 osynkade ordrar', suggestion: 'Klicka för att koppla ordrar' },
+          { id: 'qr', message: 'En QR-kod saknas', suggestion: 'Regenerera QR' },
+        ]}
+      />
+    </div>
+  );
+};
+
+export default AdminDashboardPage;

--- a/kb-foreningsportal/react-app/src/pages/admin/AdminOrgDetailPage.tsx
+++ b/kb-foreningsportal/react-app/src/pages/admin/AdminOrgDetailPage.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import QRCard from '../../components/qr/QRCard';
+import Card from '../../components/ui/Card';
+
+const AdminOrgDetailPage: React.FC = () => (
+  <div className="kb-grid">
+    <QRCard link="https://kryddbox.se/forening/if-bla" code="IFBLA2024" />
+    <Card title="Kampanj" actions={<a href="#">Visa som förening</a>}>
+      <p>Kampanjstatus: Pågående</p>
+      <p>Datum: 1 maj – 31 maj</p>
+    </Card>
+    <Card title="Material">
+      <ul className="kb-list">
+        <li className="kb-list__item">Affischer (PDF)</li>
+        <li className="kb-list__item">Flyer (PDF)</li>
+        <li className="kb-list__item">SoMe-kit</li>
+      </ul>
+    </Card>
+  </div>
+);
+
+export default AdminOrgDetailPage;

--- a/kb-foreningsportal/react-app/src/pages/admin/AdminOrgsPage.tsx
+++ b/kb-foreningsportal/react-app/src/pages/admin/AdminOrgsPage.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import Table from '../../components/ui/Table';
+import { TableRow } from '../../types';
+
+const AdminOrgsPage: React.FC = () => {
+  const data: TableRow[] = [
+    { name: 'IF Blå', campaign: 'Vår 2024', boxes: 320 },
+    { name: 'BK Röd', campaign: 'Sommar 2024', boxes: 210 },
+  ];
+
+  return (
+    <div>
+      <h2>Föreningar</h2>
+      <Table
+        columns={[
+          { header: 'Namn', accessor: 'name' },
+          { header: 'Kampanj', accessor: 'campaign' },
+          { header: 'Sålda boxar', accessor: 'boxes' },
+        ]}
+        data={data}
+      />
+    </div>
+  );
+};
+
+export default AdminOrgsPage;

--- a/kb-foreningsportal/react-app/src/pages/admin/AdminReportsPage.tsx
+++ b/kb-foreningsportal/react-app/src/pages/admin/AdminReportsPage.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Card from '../../components/ui/Card';
+import Button from '../../components/ui/Button';
+
+const AdminReportsPage: React.FC = () => (
+  <div className="kb-grid">
+    <Card title="Exportera rapporter" actions={<Button variant="primary">Exportera CSV</Button>}>
+      <p>Generera aggregerad försäljning, provision och kampanjutfall.</p>
+    </Card>
+    <Card title="Revision">
+      <p>Skapa underlag för revisorer eller externa granskare.</p>
+      <Button variant="secondary">Skapa revisionspaket</Button>
+    </Card>
+  </div>
+);
+
+export default AdminReportsPage;

--- a/kb-foreningsportal/react-app/src/pages/admin/AdminSettingsPage.tsx
+++ b/kb-foreningsportal/react-app/src/pages/admin/AdminSettingsPage.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Card from '../../components/ui/Card';
+import Button from '../../components/ui/Button';
+import Modal from '../../components/ui/Modal';
+
+const AdminSettingsPage: React.FC = () => {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <div className="kb-grid">
+      <Card title="Feature toggles" actions={<Button onClick={() => setOpen(true)}>Visa JSON</Button>}>
+        <p>Hantera globala inställningar och moduler i WordPress-admin.</p>
+      </Card>
+      <Modal title="Aktiva toggles" open={open} onClose={() => setOpen(false)}>
+        <pre>{JSON.stringify({ features: 'Laddas från WP options' }, null, 2)}</pre>
+      </Modal>
+    </div>
+  );
+};
+
+export default AdminSettingsPage;

--- a/kb-foreningsportal/react-app/src/pages/org/OrgCampaignPage.tsx
+++ b/kb-foreningsportal/react-app/src/pages/org/OrgCampaignPage.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Card from '../../components/ui/Card';
+import Button from '../../components/ui/Button';
+
+const OrgCampaignPage: React.FC = () => (
+  <div className="kb-grid">
+    <Card title="Kampanjstatus" actions={<Button variant="secondary">Redigera</Button>}>
+      <p>Status: Pågående</p>
+      <p>Period: 1 maj – 31 maj</p>
+    </Card>
+    <Card title="Automatiska utskick">
+      <ul className="kb-list">
+        <li className="kb-list__item">Startmail skickat</li>
+        <li className="kb-list__item">Mitt-i-kampanj utskick planerat</li>
+        <li className="kb-list__item">Avslutsmail planerat</li>
+      </ul>
+    </Card>
+  </div>
+);
+
+export default OrgCampaignPage;

--- a/kb-foreningsportal/react-app/src/pages/org/OrgDashboardPage.tsx
+++ b/kb-foreningsportal/react-app/src/pages/org/OrgDashboardPage.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import StatsCard from '../../components/stats/StatsCard';
+import SalesChart from '../../components/charts/SalesChart';
+import DiagnosticsPanel from '../../components/diagnostics/DiagnosticsPanel';
+
+const OrgDashboardPage: React.FC = () => (
+  <div className="kb-grid">
+    <StatsCard
+      title="Ert läge"
+      stats={[
+        { label: 'Sålda boxar', value: 85, delta: '+5 mot igår' },
+        { label: 'Provision', value: '3 400 kr' },
+        { label: 'Medlemmar som sålt', value: 22 },
+      ]}
+    />
+    <SalesChart />
+    <DiagnosticsPanel
+      issues={[
+        { id: 'material', message: 'Material ej hämtat', suggestion: 'Ladda ner affischer' },
+      ]}
+    />
+  </div>
+);
+
+export default OrgDashboardPage;

--- a/kb-foreningsportal/react-app/src/pages/org/OrgMaterialsPage.tsx
+++ b/kb-foreningsportal/react-app/src/pages/org/OrgMaterialsPage.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Card from '../../components/ui/Card';
+import Button from '../../components/ui/Button';
+
+const OrgMaterialsPage: React.FC = () => (
+  <div className="kb-grid">
+    <Card title="Affischer">
+      <Button variant="secondary">Ladda ner</Button>
+    </Card>
+    <Card title="Flyers">
+      <Button variant="secondary">Ladda ner</Button>
+    </Card>
+    <Card title="SoMe-kit">
+      <Button variant="secondary">Visa inlägg</Button>
+    </Card>
+  </div>
+);
+
+export default OrgMaterialsPage;

--- a/kb-foreningsportal/react-app/src/pages/org/OrgMembersPage.tsx
+++ b/kb-foreningsportal/react-app/src/pages/org/OrgMembersPage.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import Table from '../../components/ui/Table';
+import Button from '../../components/ui/Button';
+import { TableRow } from '../../types';
+
+const OrgMembersPage: React.FC = () => {
+  const data: TableRow[] = [
+    { name: 'Lisa', sales: 12, contact: 'lisa@example.com' },
+    { name: 'Omar', sales: 8, contact: 'omar@example.com' },
+  ];
+
+  return (
+    <div>
+      <div className="kb-toolbar">
+        <h2>Medlemmar</h2>
+        <Button variant="primary">Importera CSV</Button>
+      </div>
+      <Table
+        columns={[
+          { header: 'Namn', accessor: 'name' },
+          { header: 'Sålda boxar', accessor: 'sales' },
+          { header: 'Kontakt', accessor: 'contact' },
+        ]}
+        data={data}
+      />
+    </div>
+  );
+};
+
+export default OrgMembersPage;

--- a/kb-foreningsportal/react-app/src/styles/globals.css
+++ b/kb-foreningsportal/react-app/src/styles/globals.css
@@ -1,0 +1,179 @@
+:root {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #f7f8fa;
+  color: #1e293b;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+.kb-layout {
+  padding: 16px;
+}
+
+.kb-navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.kb-navbar__brand {
+  font-weight: 700;
+}
+
+.kb-navbar__nav {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.kb-content {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.kb-card {
+  background: #fff;
+  border-radius: 10px;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.05);
+  padding: 12px 16px;
+}
+
+.kb-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid #e2e8f0;
+  padding-bottom: 8px;
+  margin-bottom: 8px;
+}
+
+.kb-card__body {
+  display: grid;
+  gap: 12px;
+}
+
+.kb-btn {
+  border: none;
+  padding: 8px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.kb-btn--primary {
+  background: #2563eb;
+  color: #fff;
+}
+
+.kb-btn--secondary {
+  background: #e0f2fe;
+  color: #0f172a;
+}
+
+.kb-btn--ghost {
+  background: transparent;
+  color: #0f172a;
+  border: 1px solid #cbd5e1;
+}
+
+.kb-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+}
+
+.kb-table th,
+.kb-table td {
+  padding: 10px;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+}
+
+.kb-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.kb-stats__item {
+  background: #f8fafc;
+  padding: 10px;
+  border-radius: 8px;
+}
+
+.kb-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.kb-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.kb-list__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 0;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.kb-list__hint {
+  color: #64748b;
+  margin: 0;
+}
+
+.kb-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.kb-modal__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+
+.kb-modal {
+  background: #fff;
+  border-radius: 8px;
+  padding: 16px;
+  width: min(600px, 100%);
+}
+
+.kb-modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.kb-chart__placeholder {
+  padding: 20px;
+  border: 1px dashed #cbd5e1;
+  border-radius: 8px;
+  text-align: center;
+}
+
+.kb-qr__actions {
+  display: flex;
+  gap: 8px;
+}

--- a/kb-foreningsportal/react-app/src/styles/theme.css
+++ b/kb-foreningsportal/react-app/src/styles/theme.css
@@ -1,0 +1,5 @@
+:root {
+  --kb-primary: #2563eb;
+  --kb-accent: #22c55e;
+  --kb-text: #0f172a;
+}

--- a/kb-foreningsportal/react-app/src/types.ts
+++ b/kb-foreningsportal/react-app/src/types.ts
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export type PageConfig = {
+  id: string;
+  title: string;
+  element: React.ReactNode;
+};
+
+export type StatDatum = {
+  label: string;
+  value: string | number;
+  delta?: string;
+};
+
+export type TableColumn<T> = {
+  header: string;
+  accessor: keyof T;
+};
+
+export type TableRow = Record<string, string | number>;

--- a/kb-foreningsportal/react-app/tsconfig.json
+++ b/kb-foreningsportal/react-app/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/kb-foreningsportal/react-app/tsconfig.node.json
+++ b/kb-foreningsportal/react-app/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/kb-foreningsportal/react-app/vite.config.ts
+++ b/kb-foreningsportal/react-app/vite.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: path.resolve(__dirname, '../assets'),
+    emptyOutDir: false,
+    rollupOptions: {
+      input: path.resolve(__dirname, 'src/index.tsx'),
+      output: {
+        entryFileNames: 'js/portal-[name].bundle.js',
+        chunkFileNames: 'js/[name].chunk.js',
+        assetFileNames: (assetInfo) => {
+          if (assetInfo.name && assetInfo.name.endsWith('.css')) {
+            return 'css/portal.css';
+          }
+          return 'assets/[name][extname]';
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- load shared helper utilities before activation to avoid missing function errors
- guard the activator to require helpers when invoked independently of the main loader

## Testing
- find kb-foreningsportal -name "*.php" -print0 | xargs -0 -I{} php -l "{}"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693090434ba08332ac116cca92c36118)